### PR TITLE
#379 Try with resources - net.sourceforge.cobertura.javancss.parser.P…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target
+/.settings
+/.project
+/.classpath

--- a/src/main/javacc/Java1.1.jj
+++ b/src/main/javacc/Java1.1.jj
@@ -2992,7 +2992,6 @@ void TryStatement() :
 void TryBlock() :
 {}
 {
-//  LOOKAHEAD(2) "try" "(" ( LocalVariableDeclaration() [ ";" ] ")" | ")" ) Block()
   LOOKAHEAD(2) "try" "(" ( TryWithResources() ")" | ")" ) Block()
   |
   "try" Block()
@@ -3001,8 +3000,9 @@ void TryBlock() :
 void TryWithResources() :
 {}
 {
-//  LocalVariableDeclaration() [ ";" ]
-  LocalVariableDeclaration() ( ";" LocalVariableDeclaration() )*
+  LocalVariableDeclaration()
+  ( LOOKAHEAD( ";" LocalVariableDeclaration() ) ";" LocalVariableDeclaration() )*
+  [ ";" ]
 }
 
 void Identifier() :

--- a/src/test/java/javancss/test/ParseTest.java
+++ b/src/test/java/javancss/test/ParseTest.java
@@ -63,7 +63,8 @@ public class ParseTest
         _checkParse(158); // JAVANCSS-48
         _checkParse(159); // default and static method in interface
         _checkParse(160); // java8 lambda and method reference
-        _checkParse(161); // found by cobertura 
+        _checkParse(161); // found by cobertura
+        _checkParse(162); // found by cobertura (TryWithResources) 
 
         _exitSubTest();
     }

--- a/src/test/resources/Test162.java
+++ b/src/test/resources/Test162.java
@@ -1,0 +1,53 @@
+
+ package mypackage;
+ 
+ import java.sql.Connection;
+ import java.sql.PreparedStatement;
+ import java.sql.SQLException;
+ import java.sql.DriverManager;
+ 
+ public class FooMain {
+     
+     public void noSemicolonAtTheEndOfTryWithResources() throws SQLException {
+         
+         Connection connection = DriverManager.getConnection("someUrl");
+             
+         try (PreparedStatement selectStatement = connection.prepareStatement("SELECT")) {
+             
+             selectStatement.setString(1, "some.parameter.value");
+         }
+     }
+     
+     public void semicolonAtTheEndOfTryWithResources() throws SQLException {
+         
+         Connection connection = DriverManager.getConnection("someUrl");
+             
+         try (PreparedStatement selectStatement = connection.prepareStatement("SELECT");) {
+             
+             selectStatement.setString(1, "some.parameter.value");
+         }
+     }
+
+     public void noSemicolonAtTheEndOfSecondTryWithResources() throws SQLException {
+         
+         Connection connection = DriverManager.getConnection("someUrl");
+             
+         try (PreparedStatement selectStatement = connection.prepareStatement("SELECT");
+                 PreparedStatement insertStatement = connection.prepareStatement("INSERT")) {
+             
+             selectStatement.setString(1, "some.parameter.value");
+         }
+     }
+
+     public void semicolonAtTheEndOfSecondTryWithResources() throws SQLException {
+         
+         Connection connection = DriverManager.getConnection("someUrl");
+             
+         try (PreparedStatement selectStatement = connection.prepareStatement("SELECT");
+                 PreparedStatement insertStatement = connection.prepareStatement("INSERT");) {
+             
+             selectStatement.setString(1, "some.parameter.value");
+         }
+     }
+ }
+ 


### PR DESCRIPTION
…arseException: Encountered " ")" ") ""

Try resource block can have semicolon at the end of variable definition and not have another variable. Java compiler will allow one additional semicolon.

https://github.com/cobertura/cobertura/issues/379